### PR TITLE
Attempt to simplify support for numpy variable-length strings

### DIFF
--- a/h5py/_proxy.pxd
+++ b/h5py/_proxy.pxd
@@ -14,6 +14,9 @@ from numpy cimport PyArray_Descr
 cdef herr_t attr_rw(hid_t attr, hid_t mtype, void *progbuf, int read) except -1
 
 cdef herr_t dset_rw(hid_t dset, hid_t mtype, hid_t mspace, hid_t fspace,
+                    hid_t dxpl, void* progbuf, int read) except -1
+
+cdef herr_t dset_rw_vlen_strings(hid_t dset, hid_t mspace, hid_t fspace,
                     hid_t dxpl, void* progbuf, PyArray_Descr* descr,
                     int read) except -1
 

--- a/h5py/_proxy.pyx
+++ b/h5py/_proxy.pyx
@@ -188,11 +188,6 @@ cdef herr_t dset_rw_vlen_strings(hid_t dset, hid_t mspace, hid_t fspace,
     H5Tset_cset(h5_vlen_string, H5T_CSET_UTF8)
 
     try:
-        # Issue 372: when a compound type is involved, using the dataset type
-        # may result in uninitialized data being sent to H5Tconvert for fields
-        # not present in the memory type.  Limit the type used for the dataset
-        # to only those fields present in the memory type.  We can't use the
-        # memory type directly because of course that triggers HDFFV-1063.
         dstype = H5Dget_type(dset)
 
         if mspace == H5S_ALL and fspace != H5S_ALL:
@@ -211,10 +206,6 @@ cdef herr_t dset_rw_vlen_strings(hid_t dset, hid_t mspace, hid_t fspace,
 
         if read:
             H5Dread(dset, h5_vlen_string, cspace, fspace, dxpl, conv_buf)
-            # if not H5Tis_variable_str(dstype):
-            #     # Convert fixed-width bytes to char** in place.
-            #     # When dstype is already char**, H5Tconvert is a very expensive no-op.
-            #     H5Tconvert(dstype, h5_vlen_string, npoints, conv_buf, NULL, dxpl)
             # Convert contiguous char** to discontiguous NpyStrings.
             vstrings_scatter(mspace, <size_t> conv_buf, <size_t> progbuf,
                              <size_t> descr)

--- a/h5py/h5d.pxd
+++ b/h5py/h5d.pxd
@@ -13,4 +13,4 @@ from .defs cimport *
 from ._objects cimport ObjectID
 
 cdef class DatasetID(ObjectID):
-    cdef public object _dtype
+    cdef object _dtype

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -153,7 +153,7 @@ def open(ObjectID loc not None, char* name, PropID dapl=None):
 
 cdef bint _is_numpy_vlen_string(hid_t obj):
     # Check for HDF5 datatype representing numpy variable-length strings
-    # This complexity is needed to sure:
+    # This complexity is needed to ensure:
     #   1) That ctag is freed
     #   2) We don't segfault (for some reason a try-finally statement is needed,
     #   even if we do (what I think are) the right steps in copying and freeing.

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -14,18 +14,18 @@
 include "config.pxi"
 
 # Compile-time imports
-
-from collections import namedtuple
 cimport cython
+from libc.string cimport strcmp
 from ._objects cimport pdefault
 from numpy cimport ndarray, import_array, PyArray_DATA, PyArray_Descr, PyArray_DESCR
 from .utils cimport  check_numpy_read, check_numpy_write, \
                      convert_tuple, convert_dims, emalloc, efree
-from .h5t cimport TypeID, typewrap, py_create
+from .h5t cimport TypeID, typewrap, py_create, H5PY_NUMPY_STRING_TAG
 from .h5s cimport SpaceID
 from .h5p cimport PropID, propwrap
-from ._proxy cimport dset_rw
+from ._proxy cimport dset_rw, dset_rw_vlen_strings
 
+from collections import namedtuple
 from ._objects import phil, with_phil
 from cpython cimport PyBUF_ANY_CONTIGUOUS, \
                      PyBuffer_Release, \
@@ -150,7 +150,23 @@ def open(ObjectID loc not None, char* name, PropID dapl=None):
     """
     return DatasetID(H5Dopen(loc.id, name, pdefault(dapl)))
 
-# --- Proxy functions for safe(r) threading -----------------------------------
+
+cdef bint _is_numpy_vlen_string(hid_t obj):
+    # Check for HDF5 datatype representing numpy variable-length strings
+    # This complexity is needed to sure:
+    #   1) That ctag is freed
+    #   2) We don't segfault (for some reason a try-finally statement is needed,
+    #   even if we do (what I think are) the right steps in copying and freeing.
+    cdef char* ctag = NULL
+    try:
+        if H5Tget_class(obj) == H5T_OPAQUE:
+            ctag = H5Tget_tag(obj)
+            if ctag != NULL:
+                if strcmp(ctag, H5PY_NUMPY_STRING_TAG) == 0:
+                    return True
+        return False
+    finally:
+        H5free_memory(ctag)
 
 
 cdef class DatasetID(ObjectID):
@@ -240,7 +256,10 @@ cdef class DatasetID(ObjectID):
         data = PyArray_DATA(arr_obj)
         descr = PyArray_DESCR(arr_obj)
 
-        dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, descr, 1)
+        if _is_numpy_vlen_string(mtype_id):
+            dset_rw_vlen_strings(self_id, mspace_id, fspace_id, plist_id, data, descr, 1)
+        else:
+            dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, 1)
 
 
     @with_phil
@@ -282,7 +301,10 @@ cdef class DatasetID(ObjectID):
         data = PyArray_DATA(arr_obj)
         descr = PyArray_DESCR(arr_obj)
 
-        dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, descr, 0)
+        if _is_numpy_vlen_string(mtype_id):
+            dset_rw_vlen_strings(self_id, mspace_id, fspace_id, plist_id, data, descr, 0)
+        else:
+            dset_rw(self_id, mtype_id, mspace_id, fspace_id, plist_id, data, 0)
 
 
     @with_phil

--- a/h5py/h5t.pxd
+++ b/h5py/h5t.pxd
@@ -69,4 +69,5 @@ cdef class TypeCompoundID(TypeCompositeID):
 cpdef TypeID typewrap(hid_t id_)
 cdef hid_t H5PY_OBJ
 cdef char* H5PY_PYTHON_OPAQUE_TAG
+cdef char* H5PY_NUMPY_STRING_TAG
 cpdef TypeID py_create(object dtype, bint logical=*, bint aligned=*)

--- a/h5py/tests/test_npystrings.py
+++ b/h5py/tests/test_npystrings.py
@@ -51,8 +51,6 @@ def test_fromdata(writable_file):
 
 
 def test_fixed_to_variable_width(writable_file):
-    # Note: this test triggers calls to H5Tconvert which are otherwise skipped.
-
     data = ["foo", "longer than 8 bytes"]
     x = writable_file.create_dataset(
         "x", data=data, dtype=h5py.string_dtype(length=20)
@@ -145,6 +143,4 @@ def test_fillvalue(writable_file):
     assert y[0] == b"foo"
     # Convert object dtype to NpyString
     y = y.astype("T")
-    # assert isinstance(y.fillvalue, str)
-    # assert y.fillvalue == "foo"
     assert y[0] == "foo"


### PR DESCRIPTION
This is my effort to make the numpy variable-length string support work more like the other views, without adding mutable state to datasets, and without breaking the existing rules of `py_dtype()`.

You can still use `.create_dataset(data=..., dtype='T')` to make a dataset holding variable-length strings, but it doesn't 'remember' this dtype - it will behave like any other variable-length string dataset. `dset.astype('T')` is no longer writable (in keeping with other astype & asstr views), but you can write dtype T data directly into the dataset.