### PR TITLE
WIP stack overflow in scaleoffset filter

### DIFF
--- a/h5py/h5p.templ.pyx
+++ b/h5py/h5p.templ.pyx
@@ -713,8 +713,9 @@ cdef class PropDCID(PropOCID):
 
         filter_code = <int>H5Pget_filter(self.id, filter_idx, &flags,
                                          &nelements, cd_values, 256, name, NULL)
-        name[256] = c'\0'  # in case it's > 256 chars
+        assert nelements <= 16, f"H5Pget_filter returned {nelements=}"
 
+        name[256] = c'\0'  # in case it's > 256 chars
         vlist = []
         for i in range(nelements):
             vlist.append(cd_values[i])
@@ -763,9 +764,9 @@ cdef class PropDCID(PropOCID):
             # Avoid library segfault
             return None
 
-        retval = H5Pget_filter_by_id(self.id, <H5Z_filter_t>filter_code,
-                                     &flags, &nelements, cd_values, 256, name, NULL)
-        assert nelements <= 16
+        H5Pget_filter_by_id(self.id, <H5Z_filter_t>filter_code,
+                            &flags, &nelements, cd_values, 256, name, NULL)
+        assert nelements <= 16, f"H5Pget_filter_by_id returned {nelements=}"
 
         name[256] = c'\0'  # In case HDF5 doesn't terminate it properly
 


### PR DESCRIPTION
Closes #2780

At least on hdf5 2.0, the scaleoffset filter has cd_nelmts = 20.

The documentation of [H5Z_get_filter](https://support.hdfgroup.org/documentation/hdf5/latest/group___o_c_p_l.html#ga024d200a6a07e12f008a62c4e62d0bcc) states 

> On input, cd_nelmts indicates the number of entries in the cd_values array, as allocated by the caller; on return, cd_nelmts contains the number of values defined by the filter.

Note that the above implies that output cd_nelmts can be higher than the input.
h5py assumed that the output is always <= 16, and this caused a stack overflow.

## TODO
- figure out if this is a change in 2.0 or it was alwas like that
- investigate the claim that HDF5 complains if input cd_nelmts is too big, particularly in old versions
