### PR TITLE
Clean up spurious print in tests

### DIFF
--- a/h5py/tests/test_attrs_data.py
+++ b/h5py/tests/test_attrs_data.py
@@ -167,9 +167,6 @@ class TestTypes(BaseAttrs):
             data[...] = 42.3
             self.f.attrs[name] = data
             out = self.f.attrs[name]
-            # TODO: Clean up after issue addressed !
-            print("dtype: ", out.dtype, dt)
-            print("value: ", out, data)
             self.assertEqual(out.dtype, dt)
             self.assertArrayEqual(out, data)
 

--- a/h5py/tests/test_file.py
+++ b/h5py/tests/test_file.py
@@ -697,12 +697,8 @@ class TestUnicode(TestCase):
         """ Unicode filenames can be used, and seen correctly from python
         """
         fname = self.mktemp(prefix=chr(0x201a))
-        print(h5py.version.info)
-        from h5py._hl.compat import WINDOWS_ENCODING
-        print("Windows file encoding in use", WINDOWS_ENCODING)
-        print(f"Creating {fname!r}")
-        with File(fname, 'w') as f:
-            print(os.listdir(self.tempdir))
+        with File(fname, 'w'):
+            pass
         assert os.path.exists(fname)
 
     def test_nonexistent_file_unicode(self):

--- a/h5py/tests/test_h5o.py
+++ b/h5py/tests/test_h5o.py
@@ -8,8 +8,7 @@ class SampleException(Exception):
     pass
 
 def throwing(name, obj):
-    print(name, obj)
-    raise SampleException("throwing exception")
+    raise SampleException(f"throwing exception for {name} {obj}")
 
 class TestVisit(TestCase):
     def test_visit(self):


### PR DESCRIPTION
Make sure that `pytest -s` doesn't produce any spurious output.
The `-s` flag, notably, is needed when running with TSAN or ASAN (https://github.com/crusaderky/hdf5-pixi for automation) to dump out their error message to the console.